### PR TITLE
Bug cmd is visible

### DIFF
--- a/core/config/JeeMySensors.config.php
+++ b/core/config/JeeMySensors.config.php
@@ -17,64 +17,64 @@
 global $listCmdJeeMySensors;
 $listCmdJeeMySensors = array(
   'S_DOOR' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => true, 'generic_type' => 'OPENING', 'forceReturnLineAfter' => '1', 'templateDas' => 'door', 'templateMob' => 'door'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'OPENING', 'forceReturnLineAfter' => '1', 'templateDas' => 'door', 'templateMob' => 'door'),
   ),
   'S_MOTION' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => true, 'generic_type' => 'PRESENCE', 'forceReturnLineAfter' => '1', 'templateDas' => 'presence', 'templateMob' => 'presence'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'PRESENCE', 'forceReturnLineAfter' => '1', 'templateDas' => 'presence', 'templateMob' => 'presence'),
   ),
   'S_SMOKE' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => true, 'generic_type' => 'SMOKE', 'forceReturnLineAfter' => '1', 'templateDas' => 'alert', 'templateMob' => 'alert'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'SMOKE', 'forceReturnLineAfter' => '1', 'templateDas' => 'alert', 'templateMob' => 'alert'),
   ),
   'S_BINARY' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => false, 'generic_type' => 'LIGHT_STATE', 'forceReturnLineAfter' => '1', 'templateDas' => 'light', 'templateMob' => 'light'),
-    array('name' => 'On',   'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',  'order' => 2, 'isVisible' => true,  'generic_type' => 'LIGHT_ON',    'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
-    array('name' => 'Off',  'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',  'order' => 3, 'isVisible' => true,  'generic_type' => 'LIGHT_OFF',   'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => 0, 'generic_type' => 'LIGHT_STATE', 'forceReturnLineAfter' => '1', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'On',   'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',  'order' => 2, 'isVisible' => 1,  'generic_type' => 'LIGHT_ON',    'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'Off',  'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',  'order' => 3, 'isVisible' => 1,  'generic_type' => 'LIGHT_OFF',   'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
   ),
   'S_DIMMER' => array(
-    array('name' => 'Etat',        'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => false, 'generic_type' => 'LIGHT_STATE',    'forceReturnLineAfter' => '1', 'templateDas' => 'default', 'templateMob' => 'default'),
-    array('name' => 'Intensité',   'logicalId' => 'dim',  'type' => 'action', 'subType' => 'slider',  'order' => 2, 'isVisible' => true,  'generic_type' => 'LIGHT_SLIDER',    'forceReturnLineAfter' => '1', 'templateDas' => 'light', 'templateMob' => 'light'),
-    array('name' => 'On',          'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',   'order' => 3, 'isVisible' => true,  'generic_type' => 'LIGHT_ON',        'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
-    array('name' => 'Off',         'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',   'order' => 4, 'isVisible' => true,  'generic_type' => 'LIGHT_OFF',       'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'Etat',        'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 0, 'generic_type' => 'LIGHT_STATE',    'forceReturnLineAfter' => '1', 'templateDas' => 'default', 'templateMob' => 'default'),
+    array('name' => 'Intensité',   'logicalId' => 'dim',  'type' => 'action', 'subType' => 'slider',  'order' => 2, 'isVisible' => 1,  'generic_type' => 'LIGHT_SLIDER',    'forceReturnLineAfter' => '1', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'On',          'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',   'order' => 3, 'isVisible' => 1,  'generic_type' => 'LIGHT_ON',        'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'Off',         'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',   'order' => 4, 'isVisible' => 1,  'generic_type' => 'LIGHT_OFF',       'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
   ),
   'S_COVER' => array(
-    array('name' => 'Etat',        'logicalId' => 'etat',   'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => false, 'generic_type' => 'FLAP_STATE',    'forceReturnLineAfter' => '1', 'templateDas' => 'shutter', 'templateMob' => 'shutter'),
-    array('name' => 'Position',    'logicalId' => 'dim',    'type' => 'action', 'subType' => 'slider',  'order' => 2, 'isVisible' => true,  'generic_type' => 'FLAP_SLIDER',    'forceReturnLineAfter' => '1', 'templateDas' => 'shutter', 'templateMob' => 'shutter'),
-    array('name' => 'Monter',      'logicalId' => 'up',     'type' => 'action', 'subType' => 'other',   'order' => 3, 'isVisible' => true,  'generic_type' => 'FLAP_UP',        'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
-    array('name' => 'Descendre',   'logicalId' => 'down',   'type' => 'action', 'subType' => 'other',   'order' => 4, 'isVisible' => true,  'generic_type' => 'FLAP_DOWN',       'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
-    array('name' => 'Stop',        'logicalId' => 'stop',   'type' => 'action', 'subType' => 'other',   'order' => 5, 'isVisible' => true,  'generic_type' => 'FLAP_STOP',       'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
+    array('name' => 'Etat',        'logicalId' => 'etat',   'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 0, 'generic_type' => 'FLAP_STATE',    'forceReturnLineAfter' => '1', 'templateDas' => 'shutter', 'templateMob' => 'shutter'),
+    array('name' => 'Position',    'logicalId' => 'dim',    'type' => 'action', 'subType' => 'slider',  'order' => 2, 'isVisible' => 1,  'generic_type' => 'FLAP_SLIDER',    'forceReturnLineAfter' => '1', 'templateDas' => 'shutter', 'templateMob' => 'shutter'),
+    array('name' => 'Monter',      'logicalId' => 'up',     'type' => 'action', 'subType' => 'other',   'order' => 3, 'isVisible' => 1,  'generic_type' => 'FLAP_UP',        'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
+    array('name' => 'Descendre',   'logicalId' => 'down',   'type' => 'action', 'subType' => 'other',   'order' => 4, 'isVisible' => 1,  'generic_type' => 'FLAP_DOWN',       'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
+    array('name' => 'Stop',        'logicalId' => 'stop',   'type' => 'action', 'subType' => 'other',   'order' => 5, 'isVisible' => 1,  'generic_type' => 'FLAP_STOP',       'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
   ),
   'S_TEMP' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'TEMPERATURE', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'TEMPERATURE', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_HUM' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'HUMIDITY', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'HUMIDITY', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_BARO' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => true, 'generic_type' => 'PRESSURE', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'PRESSURE', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_WIND' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'WIND_SPEED', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'WIND_SPEED', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_RAIN' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'RAIN_CURRENT', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'RAIN_CURRENT', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_UV' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'UV', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'UV', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_WEIGHT' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_POWER' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'POWER', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'POWER', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_HEATER' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => true, 'generic_type' => 'HEATING_STATE', 'forceReturnLineAfter' => '1', 'templateDas' => 'heat', 'templateMob' => 'heat'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'HEATING_STATE', 'forceReturnLineAfter' => '1', 'templateDas' => 'heat', 'templateMob' => 'heat'),
   ),
   'S_DISTANCE' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_LIGHT_LEVEL' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'BRIGHTNESS', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'BRIGHTNESS', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_ARDUINO_NODE' => array(
 
@@ -83,74 +83,74 @@ $listCmdJeeMySensors = array(
 
   ),
   'S_LOCK' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => true, 'generic_type' => 'LOCK_STATE', 'forceReturnLineAfter' => '1', 'templateDas' => 'lock', 'templateMob' => 'lock'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'LOCK_STATE', 'forceReturnLineAfter' => '1', 'templateDas' => 'lock', 'templateMob' => 'lock'),
   ),
   'S_IR' => array(
 
   ),
   'S_WATER' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'CONSUMPTION', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'CONSUMPTION', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_AIR_QUALITY' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_CUSTOM' => array(
 
   ),
   'S_DUST' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_SCENE_CONTROLLER' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => false, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
-    array('name' => 'On',   'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',  'order' => 2, 'isVisible' => true, 'generic_type' => 'GENERIC',    'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
-    array('name' => 'Off',  'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',  'order' => 3, 'isVisible' => true, 'generic_type' => 'GENERIC',   'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => 0, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'On',   'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',  'order' => 2, 'isVisible' => 1, 'generic_type' => 'GENERIC',    'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
+    array('name' => 'Off',  'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',  'order' => 3, 'isVisible' => 1, 'generic_type' => 'GENERIC',   'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
   ),
   'S_RGB_LIGHT' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => false, 'generic_type' => 'LIGHT_COLOR', 'forceReturnLineAfter' => '1', 'templateDas' => 'light', 'templateMob' => 'light'),
-    array('name' => 'On',   'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',  'order' => 2, 'isVisible' => true, 'generic_type' => 'LIGHT_COLOR',    'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
-    array('name' => 'Off',  'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',  'order' => 3, 'isVisible' => true, 'generic_type' => 'LIGHT_COLOR',   'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => 0, 'generic_type' => 'LIGHT_COLOR', 'forceReturnLineAfter' => '1', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'On',   'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',  'order' => 2, 'isVisible' => 1, 'generic_type' => 'LIGHT_COLOR',    'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'Off',  'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',  'order' => 3, 'isVisible' => 1, 'generic_type' => 'LIGHT_COLOR',   'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
   ),
   'S_RGBW_LIGHT' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => false, 'generic_type' => 'LIGHT_COLOR', 'forceReturnLineAfter' => '1', 'templateDas' => 'light', 'templateMob' => 'light'),
-    array('name' => 'On',   'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',  'order' => 2, 'isVisible' => true, 'generic_type' => 'LIGHT_COLOR',    'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
-    array('name' => 'Off',  'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',  'order' => 3, 'isVisible' => true, 'generic_type' => 'LIGHT_COLOR',   'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => 0, 'generic_type' => 'LIGHT_COLOR', 'forceReturnLineAfter' => '1', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'On',   'logicalId' => 'on',   'type' => 'action', 'subType' => 'other',  'order' => 2, 'isVisible' => 1, 'generic_type' => 'LIGHT_COLOR',    'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
+    array('name' => 'Off',  'logicalId' => 'off',  'type' => 'action', 'subType' => 'other',  'order' => 3, 'isVisible' => 1, 'generic_type' => 'LIGHT_COLOR',   'forceReturnLineAfter' => '0', 'templateDas' => 'light', 'templateMob' => 'light'),
   ),
   'S_COLOR_SENSOR' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => true, 'generic_type' => 'LIGHT_COLOR', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'LIGHT_COLOR', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_HVAC' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => true, 'generic_type' => 'HEATING_STATE', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'HEATING_STATE', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_MULTIMETER' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_SPRINKLER' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_WATER_LEAK' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => true, 'generic_type' => 'FLOOD', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'binary', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'FLOOD', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_SOUND' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_VIBRATION' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_MOISTURE' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_INFO' => array(
-    array('name' => 'Etat',   'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string',   'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC_INFO',     'forceReturnLineAfter' => '1', 'templateDas' => 'default', 'templateMob' => 'default'),
-    array('name' => 'Texte',  'logicalId' => 'msg',  'type' => 'action', 'subType' => 'message',  'order' => 2, 'isVisible' => true, 'generic_type' => 'GENERIC_ACTION',   'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
+    array('name' => 'Etat',   'logicalId' => 'etat', 'type' => 'info',   'subType' => 'string',   'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC_INFO',     'forceReturnLineAfter' => '1', 'templateDas' => 'default', 'templateMob' => 'default'),
+    array('name' => 'Texte',  'logicalId' => 'msg',  'type' => 'action', 'subType' => 'message',  'order' => 2, 'isVisible' => 1, 'generic_type' => 'GENERIC_ACTION',   'forceReturnLineAfter' => '0', 'templateDas' => 'default', 'templateMob' => 'default'),
   ),
   'S_GAS' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_GPS' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
   'S_WATER_QUALITY' => array(
-    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => true, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
+    array('name' => 'Etat', 'logicalId' => 'etat', 'type' => 'info',   'subType' => 'numeric', 'order' => 1, 'isVisible' => 1, 'generic_type' => 'GENERIC', 'forceReturnLineAfter' => '1', 'templateDas' => 'line', 'templateMob' => 'line'),
   ),
 );
 ?>

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -1,6 +1,11 @@
 Changelog détaillé :
 <https://github.com/totoff974/JeeMySensors/commits/master>
 
+13-02-2022 10:00
+===
+
+- Correction de l'auto-création de commande d'un noeud : la propriété 'isVisible' en tant que boolean n'était pas reconnu en cas de valeur 'false' (traduit en chaîne vide au lieu de 0).
+
 17-01-2020 17:00
 ===
 


### PR DESCRIPTION
Bonjour,

Voici un correctif ci-dessous pour la création automatique de commande de noeuds, dû à la propriété "isVisible" lorsqu'elle était définie à "false".

Voici l'erreur provoquée au moment de la création de la commande : 
```
0342|[Sun Feb 13 10:05:45.405013 2022] [php7:error] [pid 3936747] [client 127.0.0.1:42840] PHP Fatal error:  Uncaught Exception: [MySQL] Error code : 22007 (1366). Incorrect integer value: '' for column `jeedom`.`cmd`.`isVisible` at row 1  : INSERT INTO `cmd` SET `id` = :id, `logicalId` = :logicalId, `generic_type` = :generic_type, `eqType` = :eqType, `name` = :name, `order` = :order, `type` = :type, `subType` = :subType, `eqLogic_id` = :eqLogic_id, `isHistorized` = :isHistorized, `unite` = :unite, `configuration` = :configuration, `template` = :template, `display` = :display, `value` = :value, `isVisible` = :isVisible, `alert` = :alert in /var/www/html/core/class/DB.class.php:102
0343|Stack trace:
0344|#0 /var/www/html/core/class/DB.class.php(181): DB::Prepare()
0345|#1 /var/www/html/core/class/cmd.class.php(990): DB::save()
0346|#2 /var/www/html/plugins/JeeMySensors/core/class/JeeMySensors.class.php(769): cmd->save()
0347|#3 /var/www/html/plugins/JeeMySensors/core/class/JeeMySensors.class.php(600): JeeMySensors->autoAjoutCommande()
0348|#4 /var/www/html/plugins/JeeMySensors/core/class/JeeMySensors.class.php(288): JeeMySensors::sensor_Presentat in /var/www/html/core/class/DB.class.php on line 102

```